### PR TITLE
add kyo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ val Deps = {
     val zioPrelude = "dev.zio" %% "zio-prelude" % "1.0.0-RC16"
     val turbolift = "io.github.marcinzh" %% "turbolift-core" % "0.46.0"
     val betterFiles = ("com.github.pathikrit" %% "better-files" % "3.9.1").cross(CrossVersion.for3Use2_13)
+    val kyo = "io.getkyo" %% "kyo-core-opt3" % "0.1.4" 
   }
   deps
 }
@@ -47,6 +48,7 @@ lazy val core = project
     Deps.turbolift,
     Deps.zio,
     Deps.zioPrelude,
+    Deps.kyo,
   ))
 
 lazy val chart = project

--- a/modules/bench/src/main/scala/effect_zoo/bench/contests/Cdown.scala
+++ b/modules/bench/src/main/scala/effect_zoo/bench/contests/Cdown.scala
@@ -27,6 +27,7 @@ class Cdown {
   val ZIO_Stateful__run = reg.findRound("ZIO_Stateful", 0).run
   val ZIO_Ref__run = reg.findRound("ZIO_Ref", 0).run
   val ZPure__run = reg.findRound("ZPure", 0).run
+  val Kyo__run = reg.findRound("Kyo", 0).run
   
   @Benchmark def CatsCore = CatsCore__run()
   @Benchmark def CatsMTL = CatsMTL__run()
@@ -42,4 +43,5 @@ class Cdown {
   @Benchmark def ZIO_Stateful = ZIO_Stateful__run()
   @Benchmark def ZIO_Ref = ZIO_Ref__run()
   @Benchmark def ZPure = ZPure__run()
+  @Benchmark def Kyo = Kyo__run()
 }

--- a/modules/bench/src/main/scala/effect_zoo/bench/contests/Mulst.scala
+++ b/modules/bench/src/main/scala/effect_zoo/bench/contests/Mulst.scala
@@ -33,6 +33,11 @@ class Mulst {
   val ZIO_Stateful__2__run = reg.findRound("ZIO_Stateful", 2).run
   val ZIO_Stateful__3__run = reg.findRound("ZIO_Stateful", 3).run
   val ZIO_Stateful__4__run = reg.findRound("ZIO_Stateful", 4).run
+  val Kyo__0__run = reg.findRound("Kyo", 0).run
+  val Kyo__1__run = reg.findRound("Kyo", 1).run
+  val Kyo__2__run = reg.findRound("Kyo", 2).run
+  val Kyo__3__run = reg.findRound("Kyo", 3).run
+  val Kyo__4__run = reg.findRound("Kyo", 4).run
   
   @Benchmark def CatsCore__0 = CatsCore__0__run()
   @Benchmark def CatsCore__1 = CatsCore__1__run()
@@ -54,4 +59,9 @@ class Mulst {
   @Benchmark def ZIO_Stateful__2 = ZIO_Stateful__2__run()
   @Benchmark def ZIO_Stateful__3 = ZIO_Stateful__3__run()
   @Benchmark def ZIO_Stateful__4 = ZIO_Stateful__4__run()
+  @Benchmark def Kyo__0 = Kyo__0__run()
+  @Benchmark def Kyo__1 = Kyo__1__run()
+  @Benchmark def Kyo__2 = Kyo__2__run()
+  @Benchmark def Kyo__3 = Kyo__3__run()
+  @Benchmark def Kyo__4 = Kyo__4__run()
 }

--- a/modules/core/src/main/scala/effect_zoo/contests/Cdown.scala
+++ b/modules/core/src/main/scala/effect_zoo/contests/Cdown.scala
@@ -27,4 +27,5 @@ case object Cdown extends Contest1:
       ZioStateful,
       ZioRef,
       Zpure,
+      Kyo,
     )

--- a/modules/core/src/main/scala/effect_zoo/contests/Mulst.scala
+++ b/modules/core/src/main/scala/effect_zoo/contests/Mulst.scala
@@ -1,6 +1,7 @@
 package effect_zoo.contests
 import effect_zoo.registry.{Contest5, Contender}
 
+import effect_zoo.contests.mulst.Kyo
 
 case object Mulst extends Contest5:
   override def description = "Multiple State effects used at the same time"
@@ -26,4 +27,5 @@ case object Mulst extends Contest5:
       Turbolift,
       ZioEnv,
       ZioStateful,
+      Kyo,
     )

--- a/modules/core/src/main/scala/effect_zoo/contests/cdown/Kyo.scala
+++ b/modules/core/src/main/scala/effect_zoo/contests/cdown/Kyo.scala
@@ -1,0 +1,22 @@
+package effect_zoo.contests.cdown
+
+import language.implicitConversions
+import effect_zoo.contests.{Cdown, Contender}
+import kyo.core._
+import kyo.ios._
+import kyo.concurrent.atomics._
+
+object Kyo extends Cdown.Entry(Contender.Kyo):
+  def program(a: AtomicInteger): Int > IOs =
+    a.decrementAndGet {
+      case 0 => 0
+      case _ => program(a)
+    }
+
+  override def round1 =
+    IOs.run {
+      for {
+        a <- AtomicInteger(Cdown.LIMIT)
+        v <- program(a)
+      } yield (0, v)
+    }

--- a/modules/core/src/main/scala/effect_zoo/contests/mulst/Kyo.scala
+++ b/modules/core/src/main/scala/effect_zoo/contests/mulst/Kyo.scala
@@ -1,0 +1,167 @@
+package effect_zoo.contests.mulst
+
+import kyo.core._
+import kyo.ios._
+import kyo.concurrent.atomics._
+import effect_zoo.contests.Mulst
+import effect_zoo.registry.Contender
+import language.implicitConversions
+
+object Kyo extends Mulst.Entry(Contender.Kyo):
+
+  case class Atomics(
+      a1: AtomicInteger,
+      a2: AtomicInteger,
+      a3: AtomicInteger,
+      a4: AtomicInteger,
+      a5: AtomicInteger
+  )
+
+  val atomics: Atomics > IOs =
+    for {
+      a1 <- AtomicInteger(0)
+      a2 <- AtomicInteger(0)
+      a3 <- AtomicInteger(0)
+      a4 <- AtomicInteger(0)
+      a5 <- AtomicInteger(0)
+    } yield new Atomics(a1, a2, a3, a4, a5)
+
+  override def round1 = {
+    def prog(n: Int, atomics: Atomics): Unit > IOs = {
+      import atomics._
+      if (n <= 0) {
+        IOs.unit
+      } else {
+        val update =
+          for {
+            _ <- a1.addAndGet(1)
+            _ <- a1.addAndGet(10)
+            _ <- a1.addAndGet(100)
+            _ <- a1.addAndGet(1000)
+            _ <- a1.addAndGet(10000)
+          } yield ()
+        update(_ => prog(n - 1, atomics))
+      }
+    }
+    IOs.run {
+      for {
+        a <- atomics
+        _ <- prog(Mulst.LIMIT, a)
+        v1 <- a.a1.get
+      } yield v1
+    }
+  }
+
+  override def round2 = {
+    def prog(n: Int, atomics: Atomics): Unit > IOs = {
+      import atomics._
+      if (n <= 0) {
+        IOs.unit
+      } else {
+        val update =
+          for {
+            _ <- a1.addAndGet(1)
+            _ <- a2.addAndGet(10)
+            _ <- a1.addAndGet(100)
+            _ <- a2.addAndGet(1000)
+            _ <- a1.addAndGet(10000)
+          } yield ()
+        update(_ => prog(n - 1, atomics))
+      }
+    }
+    IOs.run {
+      for {
+        a <- atomics
+        _ <- prog(Mulst.LIMIT, a)
+        v1 <- a.a1.get
+        v2 <- a.a2.get
+      } yield (v1, v2)
+    }
+  }
+
+  override def round3 = {
+    def prog(n: Int, atomics: Atomics): Unit > IOs = {
+      import atomics._
+      if (n <= 0) {
+        IOs.unit
+      } else {
+        val update =
+          for {
+            _ <- a1.addAndGet(1)
+            _ <- a2.addAndGet(10)
+            _ <- a3.addAndGet(100)
+            _ <- a1.addAndGet(1000)
+            _ <- a2.addAndGet(10000)
+          } yield ()
+        update(_ => prog(n - 1, atomics))
+      }
+    }
+    IOs.run {
+      for {
+        a <- atomics
+        _ <- prog(Mulst.LIMIT, a)
+        v1 <- a.a1.get
+        v2 <- a.a2.get
+        v3 <- a.a3.get
+      } yield (v1, v2, v3)
+    }
+  }
+
+  override def round4 = {
+    def prog(n: Int, atomics: Atomics): Unit > IOs = {
+      import atomics._
+      if (n <= 0) {
+        IOs.unit
+      } else {
+        val update =
+          for {
+            _ <- a1.addAndGet(1)
+            _ <- a2.addAndGet(10)
+            _ <- a3.addAndGet(100)
+            _ <- a4.addAndGet(1000)
+            _ <- a1.addAndGet(10000)
+          } yield ()
+        update(_ => prog(n - 1, atomics))
+      }
+    }
+    IOs.run {
+      for {
+        a <- atomics
+        _ <- prog(Mulst.LIMIT, a)
+        v1 <- a.a1.get
+        v2 <- a.a2.get
+        v3 <- a.a3.get
+        v4 <- a.a4.get
+      } yield (v1, v2, v3, v4)
+    }
+  }
+
+  override def round5 = {
+    def prog(n: Int, atomics: Atomics): Unit > IOs = {
+      import atomics._
+      if (n <= 0) {
+        IOs.unit
+      } else {
+        val update =
+          for {
+            _ <- a1.addAndGet(1)
+            _ <- a2.addAndGet(10)
+            _ <- a3.addAndGet(100)
+            _ <- a4.addAndGet(1000)
+            _ <- a5.addAndGet(10000)
+          } yield ()
+        update(_ => prog(n - 1, atomics))
+      }
+    }
+    IOs.run {
+      for {
+        a <- atomics
+        _ <- prog(Mulst.LIMIT, a)
+        v1 <- a.a1.get
+        v2 <- a.a2.get
+        v3 <- a.a3.get
+        v4 <- a.a4.get
+        v5 <- a.a5.get
+      } yield (v1, v2, v3, v4, v5)
+    }
+  }

--- a/modules/core/src/main/scala/effect_zoo/registry/Contender.scala
+++ b/modules/core/src/main/scala/effect_zoo/registry/Contender.scala
@@ -35,6 +35,7 @@ object Contender:
   case object Turbolift extends Plain
   case object ZIO extends Plain
   case object ZPure extends Plain
+  case object Kyo extends Plain
 
   val all = Vector(
     Unfunctional,
@@ -45,4 +46,5 @@ object Contender:
     Turbolift,
     ZIO,
     ZPure,
+    Kyo
   )


### PR DESCRIPTION
@fwbrasil Thanks for contribution! There are implications to consider.

Your Kyo cases do everything directly in `IOs`. 

If you look at the cases for ZIORef and CatsIO_Ref, you'll notice they pull their `Ref`s
from environment/ReaderT respectively. This was meant to imitate `State` effect.
This way, the `Ref` leaves a footprint in the type of the computation,
which is an essence of Effect System being an extension of Type System.
https://twitter.com/jdegoes/status/1601194391758327809?s=20

That said, direct use of `Ref`s is also a valid case for benchmarking.
Comparison can tell us about the overhead of interpreting effects vs. doing just `IO`.

However, we will need to level the playing field for other contenders.
After I add your cases, I will have to follow with modifications: 

1. Either add new, alternative cases, where other effect systems also use `Ref`s directly.
2. Or, add a separate contest, which would be defined as "like Cdown, but with use of `Ref`s directly instead of `State` effect"

I'm leaning towards 1.

Aside of that, it would be great if Kyo had native `States` effect.
I actually made an attempt to create it, by rewriting `Sums`.
Having that, we could add a Kyo case for `sumh` (with `Envs` as `Reader`, and `Sums` as `Writer`, and `Aborts` as `Error`)

I'm looking forward to your opinion.
